### PR TITLE
Only build alphabet over chars in pattern

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,10 +204,10 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
   ctx.lastRowMask[bMax] = 1 << ((pattern.length - 1) % w);
 
   // Calculate `ctx.peq` - the locations of chars within the pattern.
-  for (let c = 0; c < text.length; c += 1) {
-    const val = text.charCodeAt(c);
+  for (let c = 0; c < pattern.length; c += 1) {
+    const val = pattern.charCodeAt(c);
     if (ctx.peq[val]) {
-      // Duplicate char in text.
+      // Duplicate char in pattern.
       continue;
     }
 
@@ -234,6 +234,12 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
     }
   }
 
+  // Add a dummy entry for chars in the text which do not occur in the pattern.
+  ctx.peq[-1] = Array(bMax+1);
+  for (let b = 0; b <= bMax; b += 1) {
+    ctx.peq[-1][b] = 0;
+  }
+
   // Index of last-active block level in the column.
   let y = Math.max(0, Math.ceil(maxErrors / w) - 1);
 
@@ -253,7 +259,12 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
   // Process each char of the text, computing the error count for `w` chars of
   // the pattern at a time.
   for (let j = 0; j < text.length; j += 1) {
-    const ch = text.charCodeAt(j);
+    let ch = text.charCodeAt(j);
+    if (typeof ctx.peq[ch] === 'undefined') {
+      // Set char code to the placeholder that represents chars which do not
+      // occur in the pattern.
+      ch = -1;
+    }
 
     // Calculate error count for blocks that we definitely have to process for
     // this column.


### PR DESCRIPTION
The pattern is usually shorter than the text, so it is more efficient to
build an alphabet only over chars that appear in the pattern. A
placeholder character code is used to represent out-of-pattern chars.

This improves searching performance by ~25% in a test case involving
~450 public Hypothesis annotations on http://www.americanyawp.com/text/01-the-new-world/.