### PR TITLE
Optimize search using `Map` and typed arrays

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,13 +50,6 @@ function reverse(s: string) {
     .join("");
 }
 
-function fill<T>(ary: T[], x: T) {
-  for (let i = 0; i < ary.length; i += 1) {
-    ary[i] = x;
-  }
-  return ary;
-}
-
 /**
  * Given the ends of approximate matches for `pattern` in `text`, find
  * the start of the matches.
@@ -109,9 +102,9 @@ interface Context {
    * ie. `P[b][i]` is set if the vertical delta for the i'th row in the b'th
    * block is positive.
    */
-  P: number[];
+  P: Uint32Array;
   /** Bit-arrays of negative vertical deltas. */
-  M: number[];
+  M: Uint32Array;
   /**
    * Map of alphabet character value to bit-arrays indicating where that
    * character appears in the pattern.
@@ -120,9 +113,9 @@ interface Context {
    * pattern is equal to the character value `v`, where 'v' is the result of
    * String.charCodeAt(...).
    */
-  peq: Array<number[]>;
+  peq: Map<number, Uint32Array>;
   /** Bit masks with a single bit set indicating the last row in each block. */
-  lastRowMask: number[];
+  lastRowMask: Uint32Array;
 }
 
 /**
@@ -139,7 +132,7 @@ interface Context {
 function advanceBlock(ctx: Context, b: number, t: number, hIn: number) {
   let pV = ctx.P[b];
   let mV = ctx.M[b];
-  let eq = ctx.peq[t][b];
+  let eq = ctx.peq.get(t)![b];
   let hOut = 0;
 
   // Step 1: Compute horizontal deltas.
@@ -203,26 +196,27 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
   // Context used across block calculations.
   const ctx = {
     bMax,
-    P: fill(Array(bMax + 1), 0),
-    M: fill(Array(bMax + 1), 0),
-    peq: [] as Array<number[]>,
-    lastRowMask: fill(Array(bMax + 1), 1 << 31)
+    P: new Uint32Array(bMax + 1),
+    M: new Uint32Array(bMax + 1),
+    peq: new Map<number, Uint32Array>(),
+    lastRowMask: new Uint32Array(bMax + 1)
   };
+  ctx.lastRowMask.fill(1 << 31);
   ctx.lastRowMask[bMax] = 1 << (pattern.length - 1) % w;
 
   // Calculate `ctx.peq` - the locations of chars within the pattern.
   for (let c = 0; c < pattern.length; c += 1) {
     const val = pattern.charCodeAt(c);
-    if (ctx.peq[val]) {
+    if (ctx.peq.has(val)) {
       // Duplicate char in pattern.
       continue;
     }
 
     // `ctx.peq[val]` is a bit-array where each int represents a 32-char slice
     // of the pattern.
-    ctx.peq[val] = Array(bMax + 1);
+    ctx.peq.set(val, new Uint32Array(bMax + 1));
     for (let b = 0; b <= bMax; b += 1) {
-      ctx.peq[val][b] = 0;
+      ctx.peq.get(val)![b] = 0;
 
       // Set all the bits where the pattern matches the current char (ch).
       // For indexes beyond the end of the pattern, always set the bit as if the
@@ -235,23 +229,23 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
 
         const match = pattern.charCodeAt(idx) === val;
         if (match) {
-          ctx.peq[val][b] |= 1 << r;
+          ctx.peq.get(val)![b] |= 1 << r;
         }
       }
     }
   }
 
   // Add a dummy entry for chars in the text which do not occur in the pattern.
-  ctx.peq[-1] = Array(bMax + 1);
+  ctx.peq.set(-1, new Uint32Array(bMax + 1));
   for (let b = 0; b <= bMax; b += 1) {
-    ctx.peq[-1][b] = 0;
+    ctx.peq.get(-1)![b] = 0;
   }
 
   // Index of last-active block level in the column.
   let y = Math.max(0, Math.ceil(maxErrors / w) - 1);
 
   // Initialize maximum error count at bottom of each block.
-  const score = [];
+  const score = new Uint32Array(bMax + 1);
   for (let b = 0; b <= y; b += 1) {
     score[b] = (b + 1) * w;
   }
@@ -267,7 +261,7 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
   // the pattern at a time.
   for (let j = 0; j < text.length; j += 1) {
     let ch = text.charCodeAt(j);
-    if (typeof ctx.peq[ch] === "undefined") {
+    if (!ctx.peq.has(ch)) {
       // Set char code to the placeholder that represents chars which do not
       // occur in the pattern.
       ch = -1;
@@ -286,7 +280,7 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
     if (
       score[y] - carry <= maxErrors &&
       y < ctx.bMax &&
-      (ctx.peq[ch][y + 1] & 1 || carry < 0)
+      (ctx.peq.get(ch)![y + 1] & 1 || carry < 0)
     ) {
       // Error count for bottom block is under threshold, increase the number of
       // blocks processed for this column & next by 1.

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,16 +123,16 @@ interface Context {
  *
  * From Fig 8. on p. 408 of [1].
  *
+ * @param ctx - The pattern context object
+ * @param peq - The `peq` array for the current character (`ctx.peq.get(ch)`)
  * @param b - The block level
- * @param t - Character from the text, represented as
- *        a value in the `ctx.peq` alphabet.
  * @param hIn - Horizontal input delta ∈ {1,0,-1}
  * @return Horizontal output delta
  */
-function advanceBlock(ctx: Context, b: number, t: number, hIn: number) {
+function advanceBlock(ctx: Context, peq: Uint32Array, b: number, hIn: number) {
   let pV = ctx.P[b];
   let mV = ctx.M[b];
-  let eq = ctx.peq.get(t)![b];
+  let eq = peq[b];
   let hOut = 0;
 
   // Step 1: Compute horizontal deltas.
@@ -204,7 +204,9 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
   ctx.lastRowMask.fill(1 << 31);
   ctx.lastRowMask[bMax] = 1 << (pattern.length - 1) % w;
 
-  // Calculate `ctx.peq` - the locations of chars within the pattern.
+  // Calculate `ctx.peq` - a map of character values to bitmasks indicating
+  // positions of that character within the pattern, where each bit represents
+  // a position in the pattern.
   for (let c = 0; c < pattern.length; c += 1) {
     const val = pattern.charCodeAt(c);
     if (ctx.peq.has(val)) {
@@ -212,11 +214,10 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
       continue;
     }
 
-    // `ctx.peq[val]` is a bit-array where each int represents a 32-char slice
-    // of the pattern.
-    ctx.peq.set(val, new Uint32Array(bMax + 1));
+    const peq = new Uint32Array(bMax + 1);
+    ctx.peq.set(val, peq);
     for (let b = 0; b <= bMax; b += 1) {
-      ctx.peq.get(val)![b] = 0;
+      peq[b] = 0;
 
       // Set all the bits where the pattern matches the current char (ch).
       // For indexes beyond the end of the pattern, always set the bit as if the
@@ -229,17 +230,14 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
 
         const match = pattern.charCodeAt(idx) === val;
         if (match) {
-          ctx.peq.get(val)![b] |= 1 << r;
+          peq[b] |= 1 << r;
         }
       }
     }
   }
 
-  // Add a dummy entry for chars in the text which do not occur in the pattern.
-  ctx.peq.set(-1, new Uint32Array(bMax + 1));
-  for (let b = 0; b <= bMax; b += 1) {
-    ctx.peq.get(-1)![b] = 0;
-  }
+  // Dummy "peq" array for chars in the text which do not occur in the pattern.
+  const emptyPeq = new Uint32Array(bMax + 1);
 
   // Index of last-active block level in the column.
   let y = Math.max(0, Math.ceil(maxErrors / w) - 1);
@@ -260,18 +258,18 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
   // Process each char of the text, computing the error count for `w` chars of
   // the pattern at a time.
   for (let j = 0; j < text.length; j += 1) {
-    let ch = text.charCodeAt(j);
-    if (!ctx.peq.has(ch)) {
-      // Set char code to the placeholder that represents chars which do not
-      // occur in the pattern.
-      ch = -1;
+    // Lookup the bitmask representing the positions of the current char from
+    // the text within the pattern.
+    let peq = ctx.peq.get(text.charCodeAt(j));
+    if (typeof peq === "undefined") {
+      peq = emptyPeq;
     }
 
     // Calculate error count for blocks that we definitely have to process for
     // this column.
     let carry = 0;
     for (let b = 0; b <= y; b += 1) {
-      carry = advanceBlock(ctx, b, ch, carry);
+      carry = advanceBlock(ctx, peq, b, carry);
       score[b] += carry;
     }
 
@@ -280,7 +278,7 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
     if (
       score[y] - carry <= maxErrors &&
       y < ctx.bMax &&
-      (ctx.peq.get(ch)![y + 1] & 1 || carry < 0)
+      (peq[y + 1] & 1 || carry < 0)
     ) {
       // Error count for bottom block is under threshold, increase the number of
       // blocks processed for this column & next by 1.
@@ -291,7 +289,7 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
 
       const maxBlockScore = y === bMax ? pattern.length % w : w;
       score[y] =
-        score[y - 1] + maxBlockScore - carry + advanceBlock(ctx, y, ch, carry);
+        score[y - 1] + maxBlockScore - carry + advanceBlock(ctx, peq, y, carry);
     } else {
       // Error count for bottom block exceeds threshold, reduce the number of
       // blocks processed for the next column.


### PR DESCRIPTION
Analysis of profiling data and generated code in V8 showed that quite a lot of time was being spent working with holey arrays and something related to `Symbol.unscopables` which I believe relates to using arrays like dictionaries.

This PR applies a suite of optimizations which improves the runtime of a test case I'm using based on finding hundreds of short (10-300 char) strings within a large HTML document by ~40% or so under Node 12.

- Use a `Map` instead of a generic array for the character code => pattern char position associative array. My assumption here is that V8 (and other engines) are able to optimize this better because of the more constrained interface
- Eliminate several associative array lookups for character codes by re-using the results of previous lookups
- Use typed (UInt32) arrays instead of generic arrays for bitmasks. This removes the need to initialize the bitmasks to zero as typed arrays do this automatically. Typed arrays can never become holey.

As a result, this project will now only work in environments that support typed arrays (IE 10 or later, which is fine for my intended use cases) and maps (this will need to be polyfilled for IE).