### PR TITLE
Fix incorrect results when pattern is exact multiple of word size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,7 +303,14 @@ function findMatchEnds(text: string, pattern: string, maxErrors: number) {
       ctx.P[y] = ~0;
       ctx.M[y] = 0;
 
-      const maxBlockScore = y === bMax ? pattern.length % w : w;
+      let maxBlockScore;
+      if (y === bMax) {
+        const remainder = pattern.length % w;
+        maxBlockScore = remainder === 0 ? w : remainder;
+      } else {
+        maxBlockScore = w;
+      }
+
       score[y] =
         score[y - 1] +
         maxBlockScore -

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -237,4 +237,25 @@ describe("search", () => {
       assert.equal(search(text, str, 0).length, 5);
     });
   });
+
+  it("finds matches when pattern length is a multiple of block size", () => {
+    const text =
+      "for Native Americans as well.\nThe last global ice age trapped much";
+    const maxErrors = 32;
+
+    // Pattern that matches with errors, has a length that is an exact multiple
+    // of the word size, and is larger than `maxErrors` but at least word-size
+    // characters.
+    const pattern =
+      " well.\n \n2. The First Americans\nThe last global ice age trapped ";
+    assert.equal(pattern.length, 64);
+
+    const matches = search(text, pattern, maxErrors);
+    assert.equal(matches.length, 1);
+
+    const match = matches[0];
+    const matchText = text.slice(match.start, match.end);
+    assert.equal(matchText, " well.\nThe last global ice age trapped ");
+    assert.deepEqual(matches, [{ start: 23, end: 62, errors: 25 }]);
+  });
 });


### PR DESCRIPTION
Fix incorrect results from search when all of the following conditions
are met:

 1. The pattern length is an exact multiple of the word size (32)

 2. The pattern matches the text with errors

 3. The `maxErrors` param is large enough to allow a match to be found,
    but smaller than the pattern length by at least word-size chars.

There was an error in the calculation of the `maxBlockScore` variable which
should be equal to the number of characters that the pattern extends into a
block. When the pattern exactly fills the last used block it should be equal to
the word size, but instead was calculated as 0.